### PR TITLE
Add Google sign-in option

### DIFF
--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -1,6 +1,11 @@
 // screens/OnboardingScreen.js
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import * as WebBrowser from 'expo-web-browser';
+import * as Google from 'expo-auth-session/providers/google';
+import * as AuthSession from 'expo-auth-session';
+
+WebBrowser.maybeCompleteAuthSession();
 import {
   View,
   Text,
@@ -16,6 +21,23 @@ import { useNavigation } from '@react-navigation/native';
 export default function OnboardingScreen() {
   const [name, setName] = useState('');
   const navigation = useNavigation();
+
+  const [request, response, promptAsync] = Google.useAuthRequest({
+    clientId:
+      '609187760603-nvfu1qhsnt2avd2pqobjjjrcnodkhp4g.apps.googleusercontent.com',
+    redirectUri: AuthSession.makeRedirectUri({ useProxy: true }),
+    scopes: ['profile', 'email'],
+  });
+
+  useEffect(() => {
+    if (response?.type === 'success') {
+      const { authentication } = response;
+      if (authentication?.accessToken) {
+        AsyncStorage.setItem('user_token', authentication.accessToken);
+        navigation.replace('Content');
+      }
+    }
+  }, [response]);
 
   const handleContinue = async () => {
     if (name.trim()) {
@@ -44,6 +66,14 @@ export default function OnboardingScreen() {
 
         <TouchableOpacity style={styles.button} onPress={handleContinue}>
           <Text style={styles.buttonText}>Continue</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[styles.button, { marginTop: 10 }]}
+          disabled={!request}
+          onPress={() => promptAsync()}
+        >
+          <Text style={styles.buttonText}>Sign in with Google</Text>
         </TouchableOpacity>
       </View>
     </KeyboardAvoidingView>


### PR DESCRIPTION
## Summary
- add Google OAuth button using expo-auth-session
- configure useAuthRequest with provided web client ID

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684648a8f49c832cbbbe6b77f9edc8fd