### PR TITLE
Add debug logs for Google Auth redirect

### DIFF
--- a/screens/OnboardingScreen.js
+++ b/screens/OnboardingScreen.js
@@ -22,14 +22,18 @@ export default function OnboardingScreen() {
   const [name, setName] = useState('');
   const navigation = useNavigation();
 
+  const redirect = AuthSession.makeRedirectUri({ useProxy: true });
+  console.log('Generated redirect URI:', redirect);
+
   const [request, response, promptAsync] = Google.useAuthRequest({
     clientId:
       '609187760603-nvfu1qhsnt2avd2pqobjjjrcnodkhp4g.apps.googleusercontent.com',
-    redirectUri: AuthSession.makeRedirectUri({ useProxy: true }),
+    redirectUri: redirect,
     scopes: ['profile', 'email'],
   });
 
   useEffect(() => {
+    console.log('Google auth response:', response);
     if (response?.type === 'success') {
       const { authentication } = response;
       if (authentication?.accessToken) {
@@ -71,7 +75,10 @@ export default function OnboardingScreen() {
         <TouchableOpacity
           style={[styles.button, { marginTop: 10 }]}
           disabled={!request}
-          onPress={() => promptAsync()}
+          onPress={() => {
+            console.log('Starting Google OAuth with:', request?.redirectUri);
+            promptAsync();
+          }}
         >
           <Text style={styles.buttonText}>Sign in with Google</Text>
         </TouchableOpacity>


### PR DESCRIPTION
## Summary
- log the generated redirect URI used for Google OAuth
- log full Google auth responses for debugging
- log when Google OAuth is initiated

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68464e63cbc4832c949666d9f66b7e00